### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  allow:
+    - dependency-type: "direct"
+
+- package-ecosystem: "npm"
+  directory: "/packages/modal-component"
+  schedule:
+    interval: "weekly"
+  allow:
+    - dependency-type: "direct"
+
+- package-ecosystem: "npm"
+  directory: "/packages/modal-dashboard"
+  schedule:
+    interval: "weekly"
+  allow:
+    - dependency-type: "direct"


### PR DESCRIPTION
Keep package versions up to date with github dependabot: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates#enabling-github-dependabot-version-updates